### PR TITLE
Julia 0.7 fixes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.33
+Compat 0.41


### PR DESCRIPTION
Support new broadcast machinery and new typeinfo-based printing, fix uses of Void and warnings about assignments to global variable.

We don't need to support early 0.7 releases since Base.Nullable is used there.