### PR TITLE
Use broadcast_axes on 0.7

### DIFF
--- a/src/nullable.jl
+++ b/src/nullable.jl
@@ -411,9 +411,14 @@ end
 Base.BroadcastStyle(::Type{<:Nullable}) = Base.Broadcast.Style{Nullable}()
 Base.BroadcastStyle(::Base.Broadcast.Style{Nullable}, ::Base.Broadcast.DefaultArrayStyle{0}) =
     Base.Broadcast.Style{Nullable}()
-Base.broadcast_indices(::Base.Broadcast.Style{Nullable}, A) = ()
 Base.@propagate_inbounds Base.Broadcast._broadcast_getindex(::Base.Broadcast.Style{Nullable}, A, I) = A
 Base.Broadcast._broadcast_getindex_eltype(::Base.Broadcast.Style{Nullable}, A) = typeof(A)
+
+if isdefined(Base, :broadcast_axes)
+    Base.broadcast_axes(::Base.Broadcast.Style{Nullable}, A) = ()
+else
+    Base.broadcast_indices(::Base.Broadcast.Style{Nullable}, A) = ()
+end
 
 # An element type satisfying for all A:
 # unsafe_get(A)::unsafe_get_eltype(A)


### PR DESCRIPTION
Fixes a deprecation warning.