### PR TITLE
Compatibility with the 0.7 release and 1.0-rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ os:
 julia:
   - 0.6
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.6
-Compat 0.41
+Compat 0.66

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,19 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.6
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 ## uncomment the following lines to allow failures on nightly julia
 ## (tests will run but not make your overall status red)
 #matrix:
 #  allow_failures:
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-#  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+#  - julia_version: latest
 
 branches:
   only:
@@ -26,39 +27,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "
-      VERSION >= v\"0.7.0-DEV.3630\" && using InteractiveUtils; versioninfo();
-      VERSION >= v\"0.7.0-DEV.3656\" && using Pkg;
-      if VERSION < v\"0.7.0-DEV.5183\"
-          Pkg.clone(pwd(), \"Nullables\");
-          Pkg.build(\"Nullables\")
-      else
-          Pkg.build()
-      end"
-
-
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "
-      VERSION >= v\"0.7.0-DEV.3656\" && using Pkg;
-      if VERSION < v\"0.7.0-DEV.5183\"
-          Pkg.test(\"Nullables\")
-      else
-          Pkg.test()
-      end"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/Nullables.jl
+++ b/src/Nullables.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+VERSION < v"0.7.0-beta2.199" && __precompile__(true)
 module Nullables
 
 if !isdefined(Base, :NullSafeTypes)

--- a/src/nullable.jl
+++ b/src/nullable.jl
@@ -105,7 +105,7 @@ Stacktrace:
 ```
 """
 @inline function Base.get(x::Nullable{T}, y) where T
-    if isbits(T)
+    if isbitstype(T)
         ifelse(isnull(x), y, x.value)
     else
         isnull(x) ? y : x.value
@@ -191,7 +191,7 @@ returning `true` means that the operation may be called on any bit pattern witho
 throwing an error (though returning invalid or nonsensical results is not a problem).
 In particular, this means that the operation can be applied on the whole domain of the
 type *and on uninitialized objects*. As a general rule, these properties are only true for
-safe operations on `isbits` types.
+safe operations where `isbitstype` is `true`.
 
 Types declared as safe can benefit from higher performance for operations on nullable: by
 always computing the result even for null values, a branch is avoided, which helps
@@ -208,7 +208,7 @@ const NullSafeFloats = Union{Type{Float16}, Type{Float32}, Type{Float64}}
 const NullSafeTypes = Union{NullSafeInts, NullSafeFloats}
 const EqualOrLess = Union{typeof(isequal), typeof(isless)}
 
-null_safe_op(::typeof(identity), ::Type{T}) where {T} = isbits(T)
+null_safe_op(::typeof(identity), ::Type{T}) where {T} = isbitstype(T)
 
 null_safe_op(f::EqualOrLess, ::NullSafeTypes, ::NullSafeTypes) = true
 null_safe_op(f::EqualOrLess, ::Type{Rational{S}}, ::Type{T}) where {S,T} =
@@ -324,7 +324,7 @@ Nullable{Int64}()
 ```
 """
 function Base.filter(p, x::Nullable{T}) where T
-    if isbits(T)
+    if isbitstype(T)
         val = unsafe_get(x)
         Nullable{T}(val, !isnull(x) && p(val))
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Nullables
 using Compat.Test
 using Compat.Printf
 using Compat.Dates
+using Compat: isbitstype
 
 # "is a null with type T", curried on 2nd argument
 isnull_oftype(x::Nullable, T::Type) = eltype(x) == T && isnull(x)
@@ -576,7 +577,7 @@ f19270(x::S, y::T) where {S,T} = Base.promote_op(^, S, T)
 @noinline throw_error() = error()
 foo11904(x::Int) = x
 @inline function foo11904(x::Nullable{S}) where S
-    if isbits(S)
+    if isbitstype(S)
         Nullable(foo11904(x.value), x.hasvalue)
     else
         throw_error()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,7 +152,9 @@ module NullableTestEnum
         show(io, Nullable(a))
     end
 
-    if VERSION >= v"0.7.0-DEV.1877"
+    if VERSION >= v"0.7.0-DEV.2657"
+        @test String(take!(io)) == "Nullable{TestEnum}(a)"
+    elseif VERSION >= v"0.7.0-DEV.1877"
         @test String(take!(io)) == "Nullable{Main.NullableTestEnum.TestEnum}(a)"
     else
         @test String(take!(io)) == "Nullable{NullableTestEnum.TestEnum}(a)"


### PR DESCRIPTION
Adding support for 1.0 as I need this to temporarily support 0.6 - 1.0 in TimeZones.jl. I definitely will be dropping support for 0.6 when all of the internal packages we have switched to 1.0. For now this is the easiest way to get packages 1.0 compatible.